### PR TITLE
Basys mx3 audio reset fix

### DIFF
--- a/Demos/AUDIODemo.X/audio.c
+++ b/Demos/AUDIODemo.X/audio.c
@@ -317,6 +317,7 @@ void AUDIO_Close()
 {
         T3CONbits.ON = 0;       // turn off Timer3
         OC1CONbits.ON = 0;      // Turn off OC1
+        bAudioMode = -1;        // reset bAudioMode parameter
         
 }
 

--- a/Demos/BasysMX3_User_Demo.X/audio.c
+++ b/Demos/BasysMX3_User_Demo.X/audio.c
@@ -317,6 +317,7 @@ void AUDIO_Close()
 {
         T3CONbits.ON = 0;       // turn off Timer3
         OC1CONbits.ON = 0;      // Turn off OC1
+        bAudioMode = -1;        // reset bAudioMode parameter
         
 }
 

--- a/LibPack/LibPack.X/audio.c
+++ b/LibPack/LibPack.X/audio.c
@@ -317,6 +317,7 @@ void AUDIO_Close()
 {
         T3CONbits.ON = 0;       // turn off Timer3
         OC1CONbits.ON = 0;      // Turn off OC1
+        bAudioMode = -1;        // reset bAudioMode parameter
         
 }
 


### PR DESCRIPTION
incorporated audio reset so users may switch on a mode, switch it off, and then switch back on that same mode again without having to first switch to an entirely different audio mode.